### PR TITLE
FEAT: oil price

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ A3_accident.csv
 # traffic_volume folder
 
 traffic_volume_attributes.json
+
+# python
+__pycache__/

--- a/oil_price/.gitignore
+++ b/oil_price/.gitignore
@@ -1,0 +1,1 @@
+oil_price.json

--- a/oil_price/README.md
+++ b/oil_price/README.md
@@ -1,0 +1,8 @@
+# oil price
+
+We scrape price data from [history price](https://vipmbr.cpc.com.tw/mbwebs/ShowHistoryPrice_oil.aspx), and return the oil price of the given date.
+
+## packages
+
+- requests: 2.25.1
+- bs4: 0.0.2

--- a/oil_price/get_price.py
+++ b/oil_price/get_price.py
@@ -1,10 +1,11 @@
 import json
 from web_scraping import price_data_file, scrape_oil_price
 from datetime import date, timedelta
+import os
 
 def read_price_data_from_json() -> dict:
     data = None
-    with open(price_data_file, 'r') as json_file:
+    with open(price_data_file, 'r', encoding="utf-8") as json_file:
         data = json.load(json_file)
     return data
 
@@ -23,6 +24,10 @@ def data_is_outdated(price_data: dict) -> bool:
 # please give the date_string in ISO format (which is 2023-03-19 for the common used 2023/03/19)
 def get_price(date_string: str):
     target_date = date.fromisoformat(date_string)
+
+    if not os.path.exists(price_data_file):
+        print("getting price data ...")
+        scrape_oil_price()
 
     oil_price_data = read_price_data_from_json()
 

--- a/oil_price/get_price.py
+++ b/oil_price/get_price.py
@@ -1,0 +1,41 @@
+import json
+from web_scraping import price_data_file, scrape_oil_price
+from datetime import date, timedelta
+
+def read_price_data_from_json() -> dict:
+    data = None
+    with open(price_data_file, 'r') as json_file:
+        data = json.load(json_file)
+    return data
+
+def data_is_outdated(price_data: dict) -> bool:
+    latest_date = None
+    for date_string in price_data.keys():
+        price_date = date.fromisoformat(date_string)
+        if not latest_date or price_date > latest_date:
+            latest_date = price_date
+    next_price_change_date = latest_date + timedelta(days=7)
+    if date.today() > next_price_change_date:
+       return True
+    else:
+        return False
+
+# please give the date_string in ISO format (which is 2023-03-19 for the common used 2023/03/19)
+def get_price(date_string: str):
+    target_date = date.fromisoformat(date_string)
+
+    oil_price_data = read_price_data_from_json()
+
+    if data_is_outdated(oil_price_data):
+        print("updating data ...")
+        scrape_oil_price()
+        oil_price_data = read_price_data_from_json()
+
+    closest_date = None
+    for date_string in oil_price_data.keys():
+        price_date = date.fromisoformat(date_string)
+        if price_date < target_date and (not closest_date or price_date > closest_date):
+            closest_date = price_date
+    closest_date_string = date.isoformat(closest_date)
+    target_date_oil_price = oil_price_data[closest_date_string]
+    return target_date_oil_price

--- a/oil_price/web_scraping.py
+++ b/oil_price/web_scraping.py
@@ -64,7 +64,7 @@ def scrape_oil_price():
             with open(price_data_file, 'w', encoding="utf8") as json_file:
                 json.dump(oil_price, json_file, indent=4, ensure_ascii=False)
 
-            print(f"Data saved to {price_data_file}")
+            print(f"price data saved to {price_data_file}")
 
         else:
             print("Table with ID 'MyGridView' not found on the page.")

--- a/oil_price/web_scraping.py
+++ b/oil_price/web_scraping.py
@@ -1,0 +1,73 @@
+import requests
+from bs4 import BeautifulSoup
+import json
+from datetime import date
+
+oil_price_history_website_url = 'https://vipmbr.cpc.com.tw/mbwebs/ShowHistoryPrice_oil.aspx'
+required_attributes = ["調價日期", "無鉛汽油92", "無鉛汽油95", "無鉛汽油98", "超級/高級柴油"]
+required_attributes_english = [
+    "date", "gasoline-92", "gasoline-95", "gasoline-98", "diesel_fuel"]
+headers = {
+    'user-agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36'}
+price_data_file = 'oil_price.json'
+
+def date_string_to_iso_format(date_string: str) -> date:
+    date_number = date_string.split("/")
+    year = int(date_number[0])
+    month = int(date_number[1])
+    day = int(date_number[2])
+    string_date = date(year, month, day).isoformat()
+    return string_date
+
+def scrape_oil_price():
+    attribute_indices = dict()
+    oil_price = dict()
+
+    response = requests.get(oil_price_history_website_url, headers=headers)
+    if response.status_code == 200:
+
+        soup = BeautifulSoup(response.text, 'html.parser')
+        table = soup.find('table', {'id': 'MyGridView'})
+
+        if table:
+
+            rows = table.find_all('tr')
+            # dataframe attribute
+            attribute_row = rows[0]
+            all_attributes = attribute_row.find_all("th")
+            for index, attribute in enumerate(all_attributes):
+                attribute_text = attribute.get_text()
+                for required_attribute in required_attributes:
+                    if attribute_text == required_attribute:
+                        attribute_indices[required_attribute] = index
+
+            for i in range(1, len(rows)):
+                # for i in range(1, 2):
+                row = rows[i]
+                cells = row.find_all('td')
+                current_date_data = dict()
+                date = None
+                data_concat = ""
+                for index, attribute in enumerate(required_attributes):
+                    data_index = attribute_indices[attribute]
+                    data = cells[data_index].find("span").get_text()
+                    if index == 0:
+                        date = date_string_to_iso_format(data)
+                    else:
+                        data_concat += str(data)
+                        current_date_data[attribute] = str(data)
+                # make sure there is price change in 92, 95, 98 and diesel fuel
+                if data_concat != "":
+                    oil_price[date] = current_date_data
+
+            # save json file
+            with open(price_data_file, 'w', encoding="utf8") as json_file:
+                json.dump(oil_price, json_file, indent=4, ensure_ascii=False)
+
+            print(f"Data saved to {price_data_file}")
+
+        else:
+            print("Table with ID 'MyGridView' not found on the page.")
+    else:
+        print(
+            f"Failed to retrieve content. Status code: {response.status_code}")


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Testing**
- [ ] **Other (please describe)**

## Description
Scrape price data from website and return the oil price (especially for cars on highway) of the given date

## Expected behavior
After scraping the website, you should be able to see the json created as follows, and get_price() function should return the correct oil price according to the date(in ISO format) you given.
![price json screenshot](https://github.com/traffic-jam-prediction/highway_accident/assets/92793837/3b756bc6-fd63-4a5d-b384-2f2eed0606be)

## Related Issue
close #8 



